### PR TITLE
feat: assign a specific audience when retrieving tokens

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -6,7 +6,7 @@ ARG APP_VERSION
 COPY . /src
 WORKDIR /src
 RUN go mod download
-RUN GOOS=linux CGO_ENABLED=0 go build -ldflags "-s -w -X 'main.version=$APP_VERSION'" -o bootstrap ./cmd/zipstash-server
+RUN GOOS=linux CGO_ENABLED=0 go build -ldflags "-s -w -X 'main.version=$APP_VERSION'" -trimpath -o bootstrap ./cmd/zipstash-server
 
 FROM alpine:3.21
 RUN apk add ca-certificates

--- a/internal/commands/client/client.go
+++ b/internal/commands/client/client.go
@@ -11,6 +11,8 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
+const audience = "zipstash.wolfe.id.au"
+
 func newClient(endpoint, token, version string) (*client.ClientWithResponses, error) {
 
 	httpClient := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}

--- a/internal/commands/client/restore.go
+++ b/internal/commands/client/restore.go
@@ -41,7 +41,7 @@ func (c *RestoreCmd) restore(ctx context.Context, globals *commands.Globals) err
 	ctx, span := trace.Start(ctx, "RestoreCmd.restore")
 	defer span.End()
 
-	token, err := tokens.GetToken(ctx, c.TokenSource, "", nil)
+	token, err := tokens.GetToken(ctx, c.TokenSource, audience, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get token: %w", err)
 	}

--- a/internal/commands/client/save.go
+++ b/internal/commands/client/save.go
@@ -50,7 +50,7 @@ func (c *SaveCmd) save(ctx context.Context, globals *commands.Globals) error {
 		Str("sha256sum", fileInfo.Sha256sum).
 		Msg("archive built")
 
-	token, err := tokens.GetToken(ctx, c.TokenSource, "", nil)
+	token, err := tokens.GetToken(ctx, c.TokenSource, audience, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get token: %w", err)
 	}


### PR DESCRIPTION
Also use trimpath to shorten log caller paths
